### PR TITLE
Allow altering the VM memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ automate as much as possible for a simple automation setup.
 	- assuming your flake is the current directory `.` with config `utm`
 
 ```
+export VM_MEMORY=16384 # Provide this if you want to change the default 4GB VM memory to 16GB
 export VM_NAME=myVM
 nix run github:ciderale/nixos-utm#nixosCreate .#utm
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -159,6 +159,11 @@
             plutil -replace "Virtualization.Audio" -bool true "$CFG"
             plutil -replace "Virtualization.Balloon" -bool true "$CFG"
 
+            # Override default 4Gb memory
+            if [ -n "$VM_MEMORY" ]; then
+              plutil -replace "System.MemorySize" -integer "$VM_MEMORY" "$CFG"
+            fi
+
             echo -e "\n\n## refresh UTMs view of the configuration requires restarting UTM"
             killUTM
 


### PR DESCRIPTION
Add new variable `VM_MEMORY` which allows to override the default value of 4GB which UTM uses.